### PR TITLE
feat: Payco OAuth2 기반 회원가입 및 로그인 구현

### DIFF
--- a/src/main/java/shop/nuribooks/view/oauth/controller/NaverOAuth2Controller.java
+++ b/src/main/java/shop/nuribooks/view/oauth/controller/NaverOAuth2Controller.java
@@ -24,6 +24,9 @@ import shop.nuribooks.view.oauth.service.NaverOAuth2ServiceImpl;
 public class NaverOAuth2Controller {
 	private final NaverOAuth2ServiceImpl naverOAuth2Service;
 
+	@Value("${success.message-key}")
+	private String successMessageKey;
+
 	@Value("${error.message-key}")
 	private String errorMessageKey;
 
@@ -48,11 +51,13 @@ public class NaverOAuth2Controller {
 				String token = authHeader.substring(7);
 				CookieUtils.addAuthCookie(response, token);
 			}
+			redirectAttributes.addFlashAttribute(successMessageKey, "NAVER 소셜 로그인 성공!");
 			return "redirect:/";
 		} else if (result.getStatus().equals(OAuth2Status.NEED_REGISTER.toString())) {
 			// 회원가입
 			redirectAttributes.addFlashAttribute("id", result.getResponseMap().get("userInfo").get(0));
 			redirectAttributes.addFlashAttribute("email", result.getResponseMap().get("userInfo").get(1));
+			redirectAttributes.addFlashAttribute(successMessageKey, "소셜 로그인 첫 시도로 간편 회원가입이 필요합니다.");
 			return "redirect:/simple-signup";
 		} else {
 			// 이미 존재하는 정보

--- a/src/main/java/shop/nuribooks/view/oauth/controller/PaycoOAuth2Controller.java
+++ b/src/main/java/shop/nuribooks/view/oauth/controller/PaycoOAuth2Controller.java
@@ -1,8 +1,10 @@
 package shop.nuribooks.view.oauth.controller;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -11,6 +13,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.view.oauth.common.type.OAuth2Status;
+import shop.nuribooks.view.oauth.common.utils.CookieUtils;
+import shop.nuribooks.view.oauth.dto.OAuth2ResultResponse;
 import shop.nuribooks.view.oauth.service.OAuth2MemberService;
 import shop.nuribooks.view.oauth.service.PaycoOAuth2ServiceImpl;
 
@@ -19,7 +24,6 @@ import shop.nuribooks.view.oauth.service.PaycoOAuth2ServiceImpl;
 @Controller
 public class PaycoOAuth2Controller {
 	private final PaycoOAuth2ServiceImpl paycoOAuth2Service;
-	private final OAuth2MemberService oAuth2MemberService;
 
 	@Value("${error.message-key}")
 	private String errorMessageKey;
@@ -34,9 +38,33 @@ public class PaycoOAuth2Controller {
 	}
 
 	@GetMapping("/custom-login/oauth2/code/payco")
-	public String doPaycoLogin(@RequestParam("code") String code, RedirectAttributes redirectAttributes) {
-		paycoOAuth2Service.login(code);
-		redirectAttributes.addFlashAttribute(successMessageKey, "로그인 성공!");
-		return "redirect:/";
+	public String doPaycoLogin(@RequestParam("code") String code,
+		RedirectAttributes redirectAttributes,
+		HttpServletResponse response
+	) {
+		OAuth2ResultResponse result = paycoOAuth2Service.login(code);
+		if (result.getStatus().equals(OAuth2Status.LOGIN_SUCCESS.toString())) {
+			List<String> cookies = result.getResponseMap().get(HttpHeaders.SET_COOKIE);
+			// refresh jwt & 그 외 쿠키 저장
+			CookieUtils.handleCookies(cookies, response);
+			// accept jwt 쿠키로 저장
+			String authHeader = result.getResponseMap().get(HttpHeaders.AUTHORIZATION).getFirst();
+			if (authHeader != null) {
+				String token = authHeader.substring(7);
+				CookieUtils.addAuthCookie(response, token);
+			}
+			redirectAttributes.addFlashAttribute(successMessageKey, "PAYCO 소셜 로그인 성공!");
+			return "redirect:/";
+		} else if (result.getStatus().equals(OAuth2Status.NEED_REGISTER.toString())) {
+			// 회원가입
+			redirectAttributes.addFlashAttribute("id", result.getResponseMap().get("userInfo").get(0));
+			redirectAttributes.addFlashAttribute("email", result.getResponseMap().get("userInfo").get(1));
+			redirectAttributes.addFlashAttribute(successMessageKey, "소셜 로그인 첫 시도로 간편 회원가입이 필요합니다.");
+			return "redirect:/simple-signup";
+		} else {
+			// 이미 존재하는 정보
+			redirectAttributes.addFlashAttribute(errorMessageKey, "해당 이메일로 가입된 일반 계정이 존재합니다.");
+			return "redirect:/login";
+		}
 	}
 }

--- a/src/main/java/shop/nuribooks/view/oauth/service/PaycoOAuth2ServiceImpl.java
+++ b/src/main/java/shop/nuribooks/view/oauth/service/PaycoOAuth2ServiceImpl.java
@@ -1,15 +1,22 @@
 package shop.nuribooks.view.oauth.service;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.view.oauth.common.feign.OAuth2FeignClient;
 import shop.nuribooks.view.oauth.common.feign.PaycoTokenFeignClient;
 import shop.nuribooks.view.oauth.common.feign.PaycoUserInfoFeignClient;
 import shop.nuribooks.view.oauth.common.property.OAuth2ClientProperties;
+import shop.nuribooks.view.oauth.common.type.OAuth2ServicePrefix;
+import shop.nuribooks.view.oauth.common.type.OAuth2Status;
 import shop.nuribooks.view.oauth.dto.OAuth2ResultResponse;
 import shop.nuribooks.view.oauth.dto.OAuth2UserResponse;
 
@@ -20,6 +27,7 @@ public class PaycoOAuth2ServiceImpl implements OAuth2Service{
 	private final OAuth2ClientProperties oAuth2ClientProperties;
 	private final PaycoTokenFeignClient paycoTokenFeignClient;
 	private final PaycoUserInfoFeignClient paycoUserInfoFeignClient;
+	private final OAuth2FeignClient oAuth2FeignClient;
 
 	@Override
 	public String getLoginFormUri() {
@@ -44,13 +52,29 @@ public class PaycoOAuth2ServiceImpl implements OAuth2Service{
 			accessToken
 		);
 
-		Optional<OAuth2UserResponse> paycoUser = null;
-		if (isOAuth2Successful(userResponse)) {
-			paycoUser = Optional.of(getUserInfo(userResponse));
-		}
+		Optional<OAuth2UserResponse> paycoUser = Optional.of(getUserInfo(userResponse));
+		paycoUser.get().setId(OAuth2ServicePrefix.PAYCO + paycoUser.get().getId());
 
-		log.info("payco : {}", paycoUser);
-		return null;
+		// 로그인
+		ResponseEntity<String> result = oAuth2FeignClient.oauth2Login(paycoUser.get());
+		Map<String, List<String>> responseMap = new HashMap<>();
+		responseMap.put("userInfo", List.of(paycoUser.get().getId(), paycoUser.get().getEmail()));
+		if (result.getBody().equals(OAuth2Status.LOGIN_SUCCESS.toString())) {
+			setTokenToClient(result, responseMap);
+		}
+		return new OAuth2ResultResponse(responseMap, result.getBody());
+	}
+
+	private void setTokenToClient(ResponseEntity<String> result, Map<String, List<String>> responseMap) {
+		HttpHeaders headers = result.getHeaders();
+		Optional.ofNullable(headers.get(HttpHeaders.SET_COOKIE))
+			.filter(list -> !list.isEmpty())
+			.ifPresent(setCookieHeaders -> responseMap.put(HttpHeaders.SET_COOKIE, setCookieHeaders));
+
+		Optional.ofNullable(headers.get(HttpHeaders.AUTHORIZATION))
+			.filter(list -> !list.isEmpty())
+			.ifPresent(
+				setAuthorizationHeaders -> responseMap.put(HttpHeaders.AUTHORIZATION, setAuthorizationHeaders));
 	}
 
 	private String getAccessToken(Map<String, Object> tokenResponse) {
@@ -63,9 +87,5 @@ public class PaycoOAuth2ServiceImpl implements OAuth2Service{
 			.map(dataMap -> (Map<String, Object>) dataMap.get("member"))
 			.orElse(null);
 		return member != null ? new OAuth2UserResponse(member.get("idNo").toString(), member.get("email").toString()) : null;
-	}
-
-	private boolean isOAuth2Successful(Map<String, Object> userResponse) {
-		return ((Map<String, Object>)userResponse.get("header")).get("isSuccessful").toString().equalsIgnoreCase("true");
 	}
 }


### PR DESCRIPTION
Payco OAuth2 로그인 구현했습니다.

- 최초 로그인 시 : <간편 회원가입> 진행
- 소셜 로그인 이메일과 동일한 이메일이 이미 일반 가입으로 존재할 때 : 에러 메세지와 함께 로그인 창으로 보냄
- 간편 회원가입을 완료한 계정 : 소셜로그인 정상처리