### PR TITLE
Refactor/admin coupon view

### DIFF
--- a/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
@@ -71,11 +71,9 @@ public class CouponController {
 	 * @return
 	 */
 	@GetMapping("/list")
-	public String getAllCoupons(Model model, @PageableDefault Pageable pageable) {
-
-		Page<CouponResponse> combinedCoupons = couponService.getAllCoupons(pageable);
-
-		model.addAttribute("pages", combinedCoupons);
+	public String getCoupons(Model model, @PageableDefault Pageable pageable) {
+		Page<CouponResponse> coupons = this.couponService.getAllCoupons(pageable);
+		model.addAttribute("pages", coupons);
 		model.addAttribute("policyTypes", PolicyType.values());
 		model.addAttribute("couponTypes", CouponType.values());
 		model.addAttribute("expirationTypes", ExpirationType.values());

--- a/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
@@ -51,7 +51,7 @@ public class CouponController {
 	 */
 	@GetMapping
 	public String getCoupons(Model model, @PageableDefault Pageable pageable,
-		@RequestParam CouponType type) {
+		@RequestParam(name = "type", defaultValue = "ALL") CouponType type) {
 		Page<CouponResponse> coupons = couponService.getCoupons(type, pageable);
 		model.addAttribute("pages", coupons);
 		model.addAttribute("policyTypes", PolicyType.values());

--- a/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
@@ -51,7 +51,7 @@ public class CouponController {
 	 */
 	@GetMapping
 	public String getCoupons(Model model, @PageableDefault Pageable pageable,
-		@RequestParam(value = "type", defaultValue = "MiXED") CouponType type) {
+		@RequestParam CouponType type) {
 		Page<CouponResponse> coupons = couponService.getCoupons(type, pageable);
 		model.addAttribute("pages", coupons);
 		model.addAttribute("policyTypes", PolicyType.values());
@@ -78,7 +78,6 @@ public class CouponController {
 		model.addAttribute("pages", combinedCoupons);
 		model.addAttribute("policyTypes", PolicyType.values());
 		model.addAttribute("couponTypes", CouponType.values());
-		model.addAttribute("type", "MIXED");
 		model.addAttribute("expirationTypes", ExpirationType.values());
 
 		List<BookResponse> books = bookService.getAllBooks();

--- a/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
@@ -85,6 +85,24 @@ public class CouponController {
 		return "admin/coupon/coupon";
 	}
 
+	/**
+	 * 쿠폰 상세 조회
+	 * @param couponId
+	 * @param model
+	 * @return
+	 */
+	@GetMapping("/detail/{coupon-id}")
+	public String getCouponDetail(@PathVariable(name = "coupon-id") Long couponId,
+		Model model) {
+		CouponResponse couponResponse = couponService.getCouponById(couponId);
+		model.addAttribute("coupon", couponResponse);
+		model.addAttribute("policyTypes", PolicyType.values());
+		model.addAttribute("couponTypes", CouponType.values());
+		model.addAttribute("expirationTypes", ExpirationType.values());
+
+		return "admin/coupon/coupon_detail";
+	}
+
 	@GetMapping("/{couponId}")
 	public ResponseEntity<CouponResponse> getCoupon(@PathVariable Long couponId) {
 		CouponResponse couponResponse = couponService.getCouponById(couponId);

--- a/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/controller/CouponController.java
@@ -42,14 +42,43 @@ public class CouponController {
 	private final CouponService couponService;
 	private final AdminCategoryService adminCategoryService;
 
+	/**
+	 * 쿠폰 타입 별로 조회
+	 * @param model
+	 * @param pageable
+	 * @param type
+	 * @return
+	 */
 	@GetMapping
 	public String getCoupons(Model model, @PageableDefault Pageable pageable,
-		@RequestParam(value = "type", defaultValue = "ALL") CouponType type) {
+		@RequestParam(value = "type", defaultValue = "MiXED") CouponType type) {
 		Page<CouponResponse> coupons = couponService.getCoupons(type, pageable);
 		model.addAttribute("pages", coupons);
 		model.addAttribute("policyTypes", PolicyType.values());
 		model.addAttribute("couponTypes", CouponType.values());
 		model.addAttribute("type", type);
+		model.addAttribute("expirationTypes", ExpirationType.values());
+
+		List<BookResponse> books = bookService.getAllBooks();
+		model.addAttribute("books", books);
+		return "admin/coupon/coupon";
+	}
+
+	/**
+	 * 모든 쿠폰 한번에 조회
+	 * @param model
+	 * @param pageable
+	 * @return
+	 */
+	@GetMapping("/list")
+	public String getAllCoupons(Model model, @PageableDefault Pageable pageable) {
+
+		Page<CouponResponse> combinedCoupons = couponService.getAllCoupons(pageable);
+
+		model.addAttribute("pages", combinedCoupons);
+		model.addAttribute("policyTypes", PolicyType.values());
+		model.addAttribute("couponTypes", CouponType.values());
+		model.addAttribute("type", "MIXED");
 		model.addAttribute("expirationTypes", ExpirationType.values());
 
 		List<BookResponse> books = bookService.getAllBooks();

--- a/src/main/java/shop/nuribooks/view/admin/coupon/feign/CouponServiceClient.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/feign/CouponServiceClient.java
@@ -27,6 +27,9 @@ public interface CouponServiceClient {
 	@GetMapping("/api/coupons")
 	ResponseEntity<Page<CouponResponse>> getCoupons(@RequestParam(value = "type") CouponType type, Pageable pageable);
 
+	@GetMapping("/api/coupons/list")
+	ResponseEntity<Page<CouponResponse>> getAllCoupons(Pageable pageable);
+
 	@GetMapping("/api/coupons/book-coupons/{bookId}")
 	ResponseEntity<BookCouponResponse> getBookCoupon(@PathVariable("bookId") Long id);
 

--- a/src/main/java/shop/nuribooks/view/admin/coupon/service/CouponService.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/service/CouponService.java
@@ -16,6 +16,8 @@ import shop.nuribooks.view.common.dto.ResponseMessage;
 public interface CouponService {
 	Page<CouponResponse> getCoupons(CouponType type, Pageable pageable);
 
+	Page<CouponResponse> getAllCoupons(Pageable pageable);
+
 	BookCouponResponse getBookCoupon(Long id);
 
 	CategoryCouponResponse getCategoryCoupon(Long id);

--- a/src/main/java/shop/nuribooks/view/admin/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/shop/nuribooks/view/admin/coupon/service/CouponServiceImpl.java
@@ -29,6 +29,11 @@ public class CouponServiceImpl implements CouponService {
 	}
 
 	@Override
+	public Page<CouponResponse> getAllCoupons(Pageable pageable) {
+		return couponServiceClient.getAllCoupons(pageable).getBody();
+	}
+
+	@Override
 	public BookCouponResponse getBookCoupon(Long id) {
 		return this.couponServiceClient.getBookCoupon(id).getBody();
 	}

--- a/src/main/resources/templates/admin/coupon/coupon.html
+++ b/src/main/resources/templates/admin/coupon/coupon.html
@@ -35,8 +35,8 @@
                         <!--                        <th class="text-center">쿠폰 유형</th>-->
                         <!--                        <th class="text-center">정책 유형</th>-->
                         <th class="text-center">할인 할당량</th>
-                        <th class="text-center">최소 주문 금액</th>
-                        <th class="text-center">최대 할인 금액</th>
+                        <!--                        <th class="text-center">최소 주문 금액</th>-->
+                        <!--                        <th class="text-center">최대 할인 금액</th>-->
                         <th class="text-center">생성일</th>
                         <th class="text-center">만료일</th>
                         <th class="text-center">기간</th>
@@ -55,8 +55,8 @@
                             th:text="${coupon.discount.intValue() + ' ' + (coupon.policyType.toString().equals('RATED') ? '%' : '₩')}">
                             할인 할당량
                         </td>
-                        <td class="text-center" th:text="${coupon.minimumOrderPrice.intValue()}">최소 주문 금액</td>
-                        <td class="text-center" th:text="${coupon.maximumDiscountPrice.intValue()}">최대 할인 금액</td>
+                        <!--                        <td class="text-center" th:text="${coupon.minimumOrderPrice.intValue()}">최소 주문 금액</td>-->
+                        <!--                        <td class="text-center" th:text="${coupon.maximumDiscountPrice.intValue()}">최대 할인 금액</td>-->
                         <td class="text-center" th:text="${coupon.createdAt}">생성일</td>
                         <td class="text-center" th:text="${coupon.expiredAt}">만료일</td>
                         <td class="text-center" th:text="${coupon.period}">기간</td>
@@ -67,6 +67,10 @@
                         </td>
                         <td class="text-end">
                             <!-- 수정 버튼 (수정 모달 트리거) -->
+                            <a class="btn btn-outline-secondary btn-sm"
+                               th:href="@{/admin/coupon/detail/{coupon-id}(coupon-id=${coupon.id})}">
+                                <i class="fas fa-eye me-2"></i>자세히</a>
+
                             <button class="btn btn-outline-secondary btn-sm" data-bs-target="#update-modal"
                                     data-bs-toggle="modal"
                                     th:onclick="'loadCouponData(' + ${coupon.id} + ')'">

--- a/src/main/resources/templates/admin/coupon/coupon.html
+++ b/src/main/resources/templates/admin/coupon/coupon.html
@@ -13,7 +13,7 @@
                 <div>
                     <input class="form-control me-2" id="type" name="type" th:value="${type}" type="hidden"/>
 
-                    <a class="btn btn-outline-secondary me-2" href="/admin/coupon/list?type=MIXED"
+                    <a class="btn btn-outline-secondary me-2" href="/admin/coupon/list"
                        th:classappend="${type} == 'MIXED' ? 'active text-white bg-primary' : ''">모두 적용</a>
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon?type=ALL"
                        th:classappend="${type} == 'ALL' ? 'active text-white bg-primary' : ''">전체</a>

--- a/src/main/resources/templates/admin/coupon/coupon.html
+++ b/src/main/resources/templates/admin/coupon/coupon.html
@@ -13,6 +13,8 @@
                 <div>
                     <input class="form-control me-2" id="type" name="type" th:value="${type}" type="hidden"/>
 
+                    <a class="btn btn-outline-secondary me-2" href="/admin/coupon/list?type=MIXED"
+                       th:classappend="${type} == 'MIXED' ? 'active text-white bg-primary' : ''">모두 적용</a>
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon?type=ALL"
                        th:classappend="${type} == 'ALL' ? 'active text-white bg-primary' : ''">전체</a>
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon?type=BOOK"
@@ -71,10 +73,10 @@
                                 <i class="fas fa-edit me-2"></i>수정
                             </button>
 
-                            <a class="btn btn-outline-secondary btn-sm"
-                               th:onclick="'openModal(\'delete-modal\', '+ ${coupon.id} +')'">
+                            <button class="btn btn-outline-secondary btn-sm"
+                                    th:onclick="'openModal(\'delete-modal\', ' + ${coupon.id} + ')'" type="button">
                                 <i class="fas fa-trash-alt me-2"></i>만료
-                            </a>
+                            </button>
                         </td>
                     </tr>
 

--- a/src/main/resources/templates/admin/coupon/coupon.html
+++ b/src/main/resources/templates/admin/coupon/coupon.html
@@ -14,7 +14,7 @@
                     <input class="form-control me-2" id="type" name="type" th:value="${type}" type="hidden"/>
 
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon/list"
-                       th:classappend="${type} == 'MIXED' ? 'active text-white bg-primary' : ''">모두 적용</a>
+                       th:classappend="${type} != 'ALL' ? '': 'active text-white bg-primary'">모두 적용</a>
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon?type=ALL"
                        th:classappend="${type} == 'ALL' ? 'active text-white bg-primary' : ''">전체</a>
                     <a class="btn btn-outline-secondary me-2" href="/admin/coupon?type=BOOK"
@@ -32,13 +32,13 @@
                     <tr>
                         <th class="text-center">ID</th>
                         <th class="text-center">쿠폰 이름</th>
-                        <th class="text-center">쿠폰 유형</th>
-                        <th class="text-center">정책 유형</th>
+                        <!--                        <th class="text-center">쿠폰 유형</th>-->
+                        <!--                        <th class="text-center">정책 유형</th>-->
                         <th class="text-center">할인 할당량</th>
                         <th class="text-center">최소 주문 금액</th>
                         <th class="text-center">최대 할인 금액</th>
-                        <th class="text-center">시작일시</th>
-                        <th class="text-center">종료일시</th>
+                        <th class="text-center">생성일</th>
+                        <th class="text-center">만료일</th>
                         <th class="text-center">기간</th>
                         <th class="text-center">만료 유형</th>
                         <th class="text-center">활성화 여부</th>
@@ -49,20 +49,20 @@
                     <tr th:each="coupon : ${pages.content}">
                         <td class="text-center" th:text="${coupon.id}">ID</td>
                         <td class="text-center" th:text="${coupon.name}">쿠폰 이름</td>
-                        <td class="text-center" th:text="${coupon.couponType}">쿠폰 유형</td>
-                        <td class="text-center" th:text="${coupon.policyType.toKorName()}">정책 유형</td>
+                        <!--                        <td class="text-center" th:text="${coupon.couponType}">쿠폰 유형</td>-->
+                        <!--                        <td class="text-center" th:text="${coupon.policyType.toKorName()}">정책 유형</td>-->
                         <td class="text-center"
                             th:text="${coupon.discount.intValue() + ' ' + (coupon.policyType.toString().equals('RATED') ? '%' : '₩')}">
                             할인 할당량
                         </td>
                         <td class="text-center" th:text="${coupon.minimumOrderPrice.intValue()}">최소 주문 금액</td>
                         <td class="text-center" th:text="${coupon.maximumDiscountPrice.intValue()}">최대 할인 금액</td>
-                        <td class="text-center" th:text="${coupon.createdAt}">시작일시</td>
-                        <td class="text-center" th:text="${coupon.expiredAt}">종료일시</td>
+                        <td class="text-center" th:text="${coupon.createdAt}">생성일</td>
+                        <td class="text-center" th:text="${coupon.expiredAt}">만료일</td>
                         <td class="text-center" th:text="${coupon.period}">기간</td>
                         <td class="text-center" th:text="${coupon.expirationType.toKorName()}">만료 유형</td>
                         <td class="text-center"
-                            th:text="${coupon.expiredDate == null ? 'Active' : coupon.expiredDate}">
+                            th:text="${coupon.expiredDate == null ? 'Active' : #temporals.format(coupon.expiredDate, 'yyyy-MM-dd HH:mm:ss')}">
                             만료기한
                         </td>
                         <td class="text-end">

--- a/src/main/resources/templates/admin/coupon/coupon_detail.html
+++ b/src/main/resources/templates/admin/coupon/coupon_detail.html
@@ -1,0 +1,95 @@
+<html lang="ko" layout:decorate="~{admin/layout/adminlayout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org">
+<body>
+<div layout:fragment="content">
+    <div th:replace="~{admin/fragment/js-utils::utils}"></div>
+    <div class="container mt-5">
+        <div class="card shadow-sm">
+            <div class="card-header bg-primary text-white">
+
+                <h2 class="mb-0">쿠폰 상세 정보</h2>
+            </div>
+            <div class="card-body">
+                <div class="card-header">
+                    쿠폰 ID: <span th:text="${coupon.id}">ID</span>
+                </div>
+                <div class="card-body">
+                    <table class="table table-bordered">
+                        <tbody>
+                        <tr>
+                            <th>쿠폰 이름</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.name}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>쿠폰 유형</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.couponType }" type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>할인 적용 유형</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.policyType.toKorName()}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>할인 할당량</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.discount.intValue() + ' ' + (coupon.policyType.toString().equals('RATED') ? '%' : '₩')}">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>최소 주문 금액</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.minimumOrderPrice.intValue()}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>최대 할인 금액</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.maximumDiscountPrice.intValue()}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>쿠폰 생성일</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.createdAt}"
+                                       type="text"></td>
+                        </tr>
+
+                        <tr>
+                            <th>만료 유형</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.expirationType.toKorName()}" type="text">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>만료 기간</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.period}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>쿠폰 만료일</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.expiredAt != null ? coupon.expiredAt : 'N/A'}"
+                                       type="text"></td>
+                        </tr>
+                        <tr>
+                            <th>활성화 여부</th>
+                            <td><input class="form-control" readonly
+                                       th:value="${coupon.expiredDate == null ? 'Active' : '만료일자: ' + #temporals.format(coupon.expiredDate, 'yyyy-MM-dd HH:mm:ss')}"
+                                       type="text">
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <a class="btn btn-primary mt-3" href="/admin/coupon/list">목록으로 돌아가기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/shipping-policy/shipping-policy.html
+++ b/src/main/resources/templates/admin/shipping-policy/shipping-policy.html
@@ -29,7 +29,7 @@
                         <td class="text-center" th:text="${policy.shippingFee}">배송비</td>
                         <td class="text-center" th:text="${policy.minimumOrderPrice}">최소주문금액</td>
                         <td class="text-center"
-                            th:text="${policy.expiration == null ? 'Active' : policy.expiration}">
+                            th:text="${policy.expiration == null ? 'Active' : #temporals.format(policy.expiration, 'yyyy-MM-dd HH:mm:ss')}">
                             만료기한
                         </td>
                         <td class="text-end">

--- a/src/main/resources/templates/admin/shipping/shipping.html
+++ b/src/main/resources/templates/admin/shipping/shipping.html
@@ -1,5 +1,5 @@
-<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{admin/layout/adminlayout}">
+<html lang="ko" layout:decorate="~{admin/layout/adminlayout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org">
 <body>
 <div layout:fragment="content">
     <div th:replace="~{admin/fragment/js-utils::utils}"></div>
@@ -26,7 +26,7 @@
                         <td class="text-center" th:text="${shipping.orderId}">주문번호
                         </td>
                         <td class="text-center"
-                            th:text="${shipping.shippingAt != null ? shipping.shippingAt : '발송 대기'}">
+                            th:text="${shipping.shippingAt != null ? #temporals.format(shipping.shippingAt, 'yyyy-MM-dd HH:mm:ss') : '발송 대기'}">
                             발송일
                         </td>
                         <td class="text-center"
@@ -34,14 +34,15 @@
                             송장번호
                         </td>
                         <td class="text-center"
-                            th:text="${shipping.shippingCompletedAt != null ? shipping.shippingCompletedAt : (shipping.orderInvoiceNumber == null ? '배송 전' : '배송 중')}">
+                            th:text="${shipping.shippingCompletedAt != null ? #temporals.format(shipping.shippingCompletedAt, 'yyyy-MM-dd HH:mm:ss') : (shipping.orderInvoiceNumber == null ? '배송 전' : '배송 중')}">
                             배송완료날짜
                         </td>
 
                         <td class="text-end">
                             <!-- 상세보기 버튼 -->
-                            <a th:href="@{/admin/shipping/{id}(id=${shipping.id})}"
-                               class="btn btn-outline-secondary btn-sm"><i class="fas fa-eye me-2"></i>자세히</a>
+                            <a class="btn btn-outline-secondary btn-sm"
+                               th:href="@{/admin/shipping/{id}(id=${shipping.id})}"><i
+                                    class="fas fa-eye me-2"></i>자세히</a>
 
                             <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal"
                                     th:onclick="'openModal(\'update-modal\', '+ ${shipping.id} +')'">
@@ -55,7 +56,7 @@
                         </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(pages.content)}">
-                        <td colspan="6" class="text-center text-muted">등록된 배송 내역이 없습니다.</td>
+                        <td class="text-center text-muted" colspan="6">등록된 배송 내역이 없습니다.</td>
                     </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
관리자 페이지에서 쿠폰 조회시 쿠폰 타입별(도서, 카테고리, 전체쿠폰)로 조회할 수 있고, 모든 쿠폰 한번에 조회할 수 있습니다!
쿠폰 목록 페이지가 너무 복잡해서 쿠폰 상세 조회 페이지를 추가했습니다! (땡스투 용택배송기사님)

쿠폰 엔티티 수정이 끝나면 <발급수량여부, 발급가능수량> 추가 할 계획입니다!!

<img width="1188" alt="스크린샷 2024-11-29 오전 12 56 11" src="https://github.com/user-attachments/assets/2a4189d1-dcad-433a-8660-52e1513bd871">
<img width="729" alt="스크린샷 2024-11-29 오전 12 56 37" src="https://github.com/user-attachments/assets/71d5dde8-32ba-4927-b786-e4700cb9610f">